### PR TITLE
Add static admin interface and backend API

### DIFF
--- a/Media.html
+++ b/Media.html
@@ -86,21 +86,7 @@
                 <div class="container">
                     <h1 class="Anton text-center mb-5">MEDIA</h1>
                     <div class="row justify-content-center">
-                        <div class="col-lg-8">
-                            <div class="card post-card">
-                                <img src="img/projects/Mall/1.jpg" class="img-fluid" alt="Eco City update">
-                                <div class="card-body">
-                                    <h5 class="card-title">Weekly Update</h5>
-                                    <p class="card-text">Latest progress on Eco City development.</p>
-                                </div>
-                            </div>
-                            <div class="card post-card">
-                                <img src="img/projects/Mall/2.jpg" class="img-fluid" alt="Eco City event">
-                                <div class="card-body">
-                                    <h5 class="card-title">Community Event</h5>
-                                    <p class="card-text">Highlights from our weekend gathering.</p>
-                                </div>
-                            </div>
+                        <div class="col-lg-8" id="posts-container">
                         </div>
                     </div>
                 </div>
@@ -140,6 +126,23 @@
 
     <!-- Theme Initialization Files -->
     <script src="js/theme.init.js"></script>
+    <script>
+        $(function() {
+            $.getJSON('posts.json', function(data) {
+                var container = $('#posts-container');
+                container.empty();
+                data.forEach(function(post) {
+                    var card = $('<div class="card post-card mb-3"></div>');
+                    card.append('<img src="' + post.image + '" class="img-fluid" alt="' + post.title + '">');
+                    var body = $('<div class="card-body"></div>');
+                    body.append('<h5 class="card-title">' + post.title + '</h5>');
+                    body.append('<p class="card-text">' + post.text + '</p>');
+                    card.append(body);
+                    container.append(card);
+                });
+            });
+        });
+    </script>
 </body>
 
 </html>

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Admin Panel</title>
+    <link rel="stylesheet" href="vendor/bootstrap/css/bootstrap.min.css">
+    <script src="vendor/jquery/jquery.min.js"></script>
+</head>
+<body class="p-4">
+<div class="container">
+    <h1>Admin Panel</h1>
+    <div id="login-section">
+        <form id="login-form" class="mb-3" style="max-width:300px;">
+            <div class="mb-3">
+                <label class="form-label">Username</label>
+                <input type="text" name="username" class="form-control">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Password</label>
+                <input type="password" name="password" class="form-control">
+            </div>
+            <button class="btn btn-primary" type="submit">Login</button>
+        </form>
+    </div>
+    <div id="admin-section" style="display:none;">
+        <div id="message" class="alert alert-info" style="display:none;"></div>
+        <h2>Upload Downloadable File</h2>
+        <form id="upload-form" enctype="multipart/form-data" class="mb-5">
+            <div class="mb-3"><input type="file" name="file" class="form-control"></div>
+            <button class="btn btn-primary" type="submit">Upload</button>
+        </form>
+        <h2>Add Media Post</h2>
+        <form id="post-form" enctype="multipart/form-data">
+            <div class="mb-3">
+                <label class="form-label">Title</label>
+                <input type="text" name="title" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Text</label>
+                <textarea name="text" class="form-control" rows="3" required></textarea>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Image</label>
+                <input type="file" name="post_image" class="form-control">
+            </div>
+            <button class="btn btn-success" type="submit">Add Post</button>
+        </form>
+    </div>
+</div>
+<script>
+function showMessage(msg){
+    $('#message').text(msg).show();
+}
+function checkStatus(){
+    $.post('admin_api.php', {action:'status'}, function(data){
+        if(data.success){
+            $('#login-section').hide();
+            $('#admin-section').show();
+        }
+    }, 'json');
+}
+$('#login-form').on('submit', function(e){
+    e.preventDefault();
+    var formData = $(this).serializeArray();
+    formData.push({name:'action', value:'login'});
+    $.post('admin_api.php', formData, function(data){
+        if(data.success){
+            $('#login-section').hide();
+            $('#admin-section').show();
+            showMessage(data.message);
+        } else {
+            showMessage(data.message);
+        }
+    }, 'json');
+});
+$('#upload-form').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    formData.append('action','upload_file');
+    $.ajax({
+        url:'admin_api.php',
+        type:'POST',
+        data:formData,
+        processData:false,
+        contentType:false,
+        dataType:'json',
+        success:function(data){
+            showMessage(data.message);
+        }
+    });
+});
+$('#post-form').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    formData.append('action','add_post');
+    $.ajax({
+        url:'admin_api.php',
+        type:'POST',
+        data:formData,
+        processData:false,
+        contentType:false,
+        dataType:'json',
+        success:function(data){
+            showMessage(data.message);
+        }
+    });
+});
+$(checkStatus);
+</script>
+</body>
+</html>

--- a/admin_api.php
+++ b/admin_api.php
@@ -1,0 +1,74 @@
+<?php
+session_start();
+$logged_in = isset($_SESSION['logged_in']) && $_SESSION['logged_in'];
+$upload_dir = __DIR__ . '/downloads/';
+$posts_file = __DIR__ . '/posts.json';
+$images_dir = __DIR__ . '/img/media_uploads/';
+
+$response = ['success' => false, 'message' => ''];
+
+if (isset($_POST['action'])) {
+    switch ($_POST['action']) {
+        case 'login':
+            $user = $_POST['username'] ?? '';
+            $pass = $_POST['password'] ?? '';
+            if ($user === 'admin' && $pass === 'password') {
+                $_SESSION['logged_in'] = true;
+                $logged_in = true;
+                $response['success'] = true;
+                $response['message'] = 'Logged in.';
+            } else {
+                $response['message'] = 'Invalid credentials.';
+            }
+            break;
+        case 'upload_file':
+            if ($logged_in && isset($_FILES['file'])) {
+                $target = $upload_dir . basename($_FILES['file']['name']);
+                if (move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
+                    $response['success'] = true;
+                    $response['message'] = 'File uploaded.';
+                } else {
+                    $response['message'] = 'Upload failed.';
+                }
+            } else {
+                $response['message'] = 'Not logged in.';
+            }
+            break;
+        case 'add_post':
+            if ($logged_in) {
+                $title = trim($_POST['title'] ?? '');
+                $text = trim($_POST['text'] ?? '');
+                $image_path = '';
+                if (!empty($_FILES['post_image']['name'])) {
+                    $image_target = $images_dir . basename($_FILES['post_image']['name']);
+                    if (move_uploaded_file($_FILES['post_image']['tmp_name'], $image_target)) {
+                        $image_path = 'img/media_uploads/' . basename($_FILES['post_image']['name']);
+                    }
+                }
+                if ($title && $text) {
+                    $posts = file_exists($posts_file) ? json_decode(file_get_contents($posts_file), true) : [];
+                    $posts[] = ['title' => $title, 'text' => $text, 'image' => $image_path];
+                    file_put_contents($posts_file, json_encode($posts, JSON_PRETTY_PRINT));
+                    $response['success'] = true;
+                    $response['message'] = 'Post added.';
+                } else {
+                    $response['message'] = 'Missing title or text.';
+                }
+            } else {
+                $response['message'] = 'Not logged in.';
+            }
+            break;
+        case 'status':
+            $response['success'] = $logged_in;
+            break;
+        case 'logout':
+            $_SESSION['logged_in'] = false;
+            $response['success'] = true;
+            break;
+        default:
+            $response['message'] = 'Unknown action.';
+    }
+}
+
+header('Content-Type: application/json');
+echo json_encode($response);

--- a/header.html
+++ b/header.html
@@ -65,6 +65,9 @@
                                             Contact Us
                                         </a>
                                     </li>
+                                    <li>
+                                        <a class="nav-link" href="admin.html">Admin</a>
+                                    </li>
                                 </ul>
                             </nav>
                         </div>

--- a/posts.json
+++ b/posts.json
@@ -1,0 +1,12 @@
+[
+  {
+    "title": "Weekly Update",
+    "text": "Latest progress on Eco City development.",
+    "image": "img/projects/Mall/1.jpg"
+  },
+  {
+    "title": "Community Event",
+    "text": "Highlights from our weekend gathering.",
+    "image": "img/projects/Mall/2.jpg"
+  }
+]


### PR DESCRIPTION
## Summary
- replace `admin.php` with new `admin_api.php` endpoint
- add `admin.html` front-end for admin actions
- update navigation link to `admin.html`

## Testing
- `php -l admin_api.php`
- `tidy` not available so HTML validation skipped


------
https://chatgpt.com/codex/tasks/task_e_6850b9f3f9cc8320b32d11a3b0bc22f7